### PR TITLE
Reduce file quality and take arguments from user

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import logging
 import pyheif
 from PIL import Image
+from sys import argv
 
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 
@@ -41,7 +42,7 @@ def convert_heic_to_jpg(heic_dir):
 
             # Save the image as JPG
             with open(jpg_path, "wb") as jpg_file:
-                image.save(jpg_file, "JPEG", quality=100)
+                image.save(jpg_file, "JPEG", quality=50)
                 num_converted += 1
 
             # Calculate and display the percentage progress
@@ -53,7 +54,7 @@ def convert_heic_to_jpg(heic_dir):
     print(f"\nConversion completed successfully. {num_converted} files converted.")
 
 # Provide the directory path containing the HEIC files
-heic_directory = "/path/to/heic"
+heic_directory = argv[1]
 
 # Convert HEIC to JPG
 convert_heic_to_jpg(heic_directory)


### PR DESCRIPTION
I noticed the source file size is around 3-4 MB and the output JPG file is almost 15-20 MB for some reason. Downgrading quality to that of 50 keeps the size same. 

Additionally, taking the directory as a argument instead of being hard coded inside the code. 