### PR TITLE
Add PEP 723 script dependencies to use with uv

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#   "pillow==11.0.0",
+#   "pillow_heif==0.18.0",
+# ]
+# ///
+
 import os
 import logging
 import argparse


### PR DESCRIPTION
Eg, now you can do:

```
uv run main.py <path/to/your/heic/directory>
```

And it automatically downloads pillow and pillow_heif for you.